### PR TITLE
BACKLOG-14793: Return most popular movies on empty query

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.jahia.modules</groupId>
       <artifactId>external-provider</artifactId>
-      <version>3.0.5</version>
+      <version>4.0.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -53,6 +53,7 @@
           <instructions>
             <Import-Package>
               org.jahia.modules.external; version="[2.0,5)",
+              org.jahia.modules.external.events; version="[2.0,5)",
               org.jahia.modules.external.query; version="[2.0,5)",
               javax.jcr,
               org.jahia.services.content,

--- a/src/main/java/org/jahia/modules/tmdbprovider/TMDBDataSource.java
+++ b/src/main/java/org/jahia/modules/tmdbprovider/TMDBDataSource.java
@@ -88,7 +88,7 @@ public class TMDBDataSource implements ExternalDataSource, ExternalDataSource.La
     public List<String> getChildren(String path) throws RepositoryException {
         DateTime currentDate = new DateTime();
         int yearLimit = currentDate.getYear();
-        int monthLimit = currentDate.getMonthOfYear()-1;
+        int monthLimit = currentDate.getMonthOfYear() - 1;
 
         List<String> r = new ArrayList<String>();
 
@@ -177,7 +177,7 @@ public class TMDBDataSource implements ExternalDataSource, ExternalDataSource.La
                             cache.put(new Element("fulllist-" + splitPath[2], list.toString()));
                         }
                         JSONArray result = list.getJSONArray("items");
-                        for (int i = 0; i < Math.min(result.length(),20); i++) {
+                        for (int i = 0; i < Math.min(result.length(), 20); i++) {
                             JSONObject movie = result.getJSONObject(i);
                             r.add(movie.getString("id"));
                             cache.put(new Element("movieref-" + movie.getString("id"), movie.toString()));
@@ -203,7 +203,6 @@ public class TMDBDataSource implements ExternalDataSource, ExternalDataSource.La
      * @param identifier
      * @return ExternalData defined by the identifier
      * @throws javax.jcr.ItemNotFoundException
-     *
      */
     @Override
     public ExternalData getItemByIdentifier(String identifier) throws ItemNotFoundException {
@@ -292,8 +291,8 @@ public class TMDBDataSource implements ExternalDataSource, ExternalDataSource.La
                 ExternalData data = null;
                 if (creditsId.startsWith("crew_")) {
                     String id = StringUtils.substringAfter(creditsId, "crew_");
-                    String job = StringUtils.substringBefore(id,"_");
-                    id = StringUtils.substringAfter(id,"_");
+                    String job = StringUtils.substringBefore(id, "_");
+                    id = StringUtils.substringAfter(id, "_");
                     JSONArray a = o.getJSONArray("crew");
                     for (int i = 0; i < a.length(); i++) {
                         JSONObject crew = a.getJSONObject(i);
@@ -305,14 +304,14 @@ public class TMDBDataSource implements ExternalDataSource, ExternalDataSource.La
                             if (credit.getString("job") != null)
                                 properties.put("job", new String[]{credit.getString("job")});
                             if (credit.getString("id") != null)
-                                properties.put("person", new String[]{"person-"+credit.getString("id")});
+                                properties.put("person", new String[]{"person-" + credit.getString("id")});
                             break;
                         }
                     }
                 } else if (creditsId.startsWith("cast_")) {
                     String id = StringUtils.substringAfter(creditsId, "cast_");
-                    String castId = StringUtils.substringBefore(id,"_");
-                    id = StringUtils.substringAfter(id,"_");
+                    String castId = StringUtils.substringBefore(id, "_");
+                    id = StringUtils.substringAfter(id, "_");
                     JSONArray a = o.getJSONArray("cast");
                     for (int i = 0; i < a.length(); i++) {
                         JSONObject cast = a.getJSONObject(i);
@@ -326,7 +325,7 @@ public class TMDBDataSource implements ExternalDataSource, ExternalDataSource.La
                             if (credit.getString("cast_id") != null)
                                 properties.put("cast_id", new String[]{credit.getString("cast_id")});
                             if (credit.getString("id") != null)
-                                properties.put("person", new String[]{"person-"+credit.getString("id")});
+                                properties.put("person", new String[]{"person-" + credit.getString("id")});
                             break;
                         }
                     }
@@ -442,7 +441,6 @@ public class TMDBDataSource implements ExternalDataSource, ExternalDataSource.La
      * @param path
      * @return ExternalData
      * @throws javax.jcr.PathNotFoundException
-     *
      */
     @Override
     public ExternalData getItemByPath(String path) throws PathNotFoundException {
@@ -503,7 +501,7 @@ public class TMDBDataSource implements ExternalDataSource, ExternalDataSource.La
      * Indicates if this data source has path-like hierarchical external identifiers, e.g. IDs that are using file system paths.
      *
      * @return <code>true</code> if this data source has path-like hierarchical external identifiers, e.g. IDs that are using file system
-     *         paths; <code>false</code> otherwise.
+     * paths; <code>false</code> otherwise.
      */
     @Override
     public boolean isSupportsHierarchicalIdentifiers() {
@@ -551,7 +549,7 @@ public class TMDBDataSource implements ExternalDataSource, ExternalDataSource.La
                 return new JSONObject(httpMethod.getResponseBodyAsString());
             } finally {
                 httpMethod.releaseConnection();
-                System.out.println("Request " + url + " done in "+(System.currentTimeMillis()-l) + "ms");
+                System.out.println("Request " + url + " done in " + (System.currentTimeMillis() - l) + "ms");
             }
         } catch (Exception e) {
             throw new RepositoryException(e);
@@ -621,19 +619,31 @@ public class TMDBDataSource implements ExternalDataSource, ExternalDataSource.La
         try {
             if (NodeTypeRegistry.getInstance().getNodeType("jnt:movie").isNodeType(nodeType)) {
                 JSONArray tmdbResult = null;
-                String year;
-                String month;
 
                 Map<String, Value> m = QueryHelper.getSimpleOrConstraints(query.getConstraint());
                 if (m.containsKey("jcr:title")) {
                     tmdbResult = queryTMDB(API_SEARCH_MOVIE, "query", m.get("jcr:title").getString()).getJSONArray("results");
-                }
-
-                if (tmdbResult != null) {
-                    for (int i = 0; i < tmdbResult.length(); i++) {
-                        final String path = getPathForMovie(tmdbResult.getJSONObject(i));
-                        if (path != null) {
-                            results.add(path);
+                    if (tmdbResult != null) {
+                        processResultsArray(results, tmdbResult);
+                    }
+                } else {
+                    long pageNumber = query.getOffset() / 20;
+                    if (pageNumber < 100) {
+                        //Return up to the first 2000 most popular movies
+                        JSONObject discoverMovies = queryTMDB(API_DISCOVER_MOVIE, "sort_by", "popularity.desc", "page", String.valueOf(pageNumber + 1));
+                        if(discoverMovies.has("total_pages") && discoverMovies.has("results")) {
+                            int totalPages = discoverMovies.getInt("total_pages");
+                            tmdbResult = discoverMovies.getJSONArray("results");
+                            if (tmdbResult != null) {
+                                processResultsArray(results, tmdbResult);
+                            }
+                            for (long i = pageNumber + 2; i <= totalPages; i++) {
+                                processResultsArray(results, queryTMDB(API_DISCOVER_MOVIE, "sort_by", "popularity.desc", "page", String.valueOf(i)).getJSONArray(
+                                        "results"));
+                                if (results.size() >= query.getLimit()) {
+                                    break;
+                                }
+                            }
                         }
                     }
                 }
@@ -651,15 +661,15 @@ public class TMDBDataSource implements ExternalDataSource, ExternalDataSource.La
             }
 
             if (NodeTypeRegistry.getInstance().getNodeType("jnt:cast").isNodeType(nodeType)) {
-                Map<String,Value> m = QueryHelper.getSimpleAndConstraints(query.getConstraint());
+                Map<String, Value> m = QueryHelper.getSimpleAndConstraints(query.getConstraint());
                 if (m.containsKey("id")) {
                     final String id = m.get("id").getString();
                     JSONObject search;
-                    if (cache.get("movie_credits_query_"+id) != null) {
-                        search = new JSONObject((String) cache.get("movie_credits_query_"+id).getObjectValue());
+                    if (cache.get("movie_credits_query_" + id) != null) {
+                        search = new JSONObject((String) cache.get("movie_credits_query_" + id).getObjectValue());
                     } else {
                         search = queryTMDB("/3/person/" + id + "/movie_credits");
-                        cache.put(new Element("movie_credits_query_"+id, search.toString()));
+                        cache.put(new Element("movie_credits_query_" + id, search.toString()));
                     }
 
                     JSONArray result = search.getJSONArray("cast");
@@ -681,15 +691,15 @@ public class TMDBDataSource implements ExternalDataSource, ExternalDataSource.La
             }
 
             if (NodeTypeRegistry.getInstance().getNodeType("jnt:crew").isNodeType(nodeType)) {
-                Map<String,Value> m = QueryHelper.getSimpleAndConstraints(query.getConstraint());
+                Map<String, Value> m = QueryHelper.getSimpleAndConstraints(query.getConstraint());
                 if (m.containsKey("id")) {
                     final String id = m.get("id").getString();
                     JSONObject search;
-                    if (cache.get("movie_credits_query_"+id) != null) {
-                        search = new JSONObject((String) cache.get("movie_credits_query_"+id).getObjectValue());
+                    if (cache.get("movie_credits_query_" + id) != null) {
+                        search = new JSONObject((String) cache.get("movie_credits_query_" + id).getObjectValue());
                     } else {
                         search = queryTMDB("/3/person/" + id + "/movie_credits");
-                        cache.put(new Element("movie_credits_query_"+id, search.toString()));
+                        cache.put(new Element("movie_credits_query_" + id, search.toString()));
                     }
 
                     JSONArray result = search.getJSONArray("crew");
@@ -698,7 +708,7 @@ public class TMDBDataSource implements ExternalDataSource, ExternalDataSource.La
                         ExternalData d = getItemByIdentifier("movie-" + r.getString("id"));
                         if (d != null && d.getPath() != null) {
                             for (String s : getChildren(d.getPath())) {
-                                if (s.endsWith("_"+r.getString("job") + "_" +id)) {
+                                if (s.endsWith("_" + r.getString("job") + "_" + id)) {
                                     results.add(d.getPath() + "/" + s);
                                     if (results.size() == 20) {
                                         return results;
@@ -715,6 +725,15 @@ public class TMDBDataSource implements ExternalDataSource, ExternalDataSource.La
             throw new RepositoryException(e);
         }
         return results;
+    }
+
+    private void processResultsArray(List<String> results, JSONArray tmdbResult) throws JSONException {
+        for (int i = 0; i < tmdbResult.length(); i++) {
+            final String path = getPathForMovie(tmdbResult.getJSONObject(i));
+            if (path != null) {
+                results.add(path);
+            }
+        }
     }
 
     private String getAccountId() throws RepositoryException, JSONException {


### PR DESCRIPTION


This allow Augmented Search to index at least 2000 movies on indexation

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-14793

## Description

if query is matching "select * from [jnt:movie]", up to 2000 movies following pagination (limit/offset).

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
